### PR TITLE
Fixes #8713: Colorize requires explicit tool specified

### DIFF
--- a/plugins/colorize/README.md
+++ b/plugins/colorize/README.md
@@ -6,28 +6,29 @@ Colorize will highlight the content based on the filename extension. If it can't
 method for a given extension, it will try to find one by looking at the file contents. If no highlight method
 is found it will just cat the file normally, without syntax highlighting.
 
-## Setup
-
-To use it, add colorize to the plugins array of your `~/.zshrc` file:
-```
-plugins=(... colorize)
-```
-
 ## Configuration
 
 ### Requirements
 
-This plugin requires that at least one of the following tools is installed:
+This plugin requires that at least one of the following syntax highlighting tools is installed:
 
 * [Chroma](https://github.com/alecthomas/chroma)
 * [Pygments](https://pygments.org/download/)
 
-### Colorize tool
 
-Colorize supports `pygmentize` and `chroma` as syntax highlighter. By default colorize uses `pygmentize` unless it's not installed and `chroma` is. This can be overridden by the `ZSH_COLORIZE_TOOL` environment variable:
+### Setup
 
+Specify which installed tool you would like to use with the `ZSH_COLORIZE_TOOL` environment variable in `.zshrc` above the lines specifyng the oh-my-zsh plugins. Either:
+
+```ZSH_COLORIZE_TOOL=pygmentize```
+
+or
+
+```ZSH_COLORIZE_TOOL=chroma```
+
+Then enable colorize by adding it to the plugins array of your `~/.zshrc` file:
 ```
-ZSH_COLORIZE_TOOL=chroma
+plugins=(... colorize)
 ```
 
 ### Styles


### PR DESCRIPTION
The instructions imply that the `ZSH_COLORIZE_TOOL` doesn't need to be set if Pygments is installed. However, I've found that on both Mac (Calatina) and in Manjaro, that even though when `which pygmentize` shows that `pygmentize` exists in the `$PATH` variable, the plugin won't find it.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Clarification of README.md